### PR TITLE
feat/SOF-6914: bump esse version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1350,36 +1350,6 @@
             "integrity": "sha512-2da786Y5j3soXcxRi/MST6qc2aIUgTjCjcqfm+xQkGfJSV8FaQR/jccENLZ5i5ynYUMqQ8Elir2Q3n4LBFqeBg==",
             "dev": true
         },
-        "@exabyte-io/esse.js": {
-            "version": "git+https://github.com/Exabyte-io/esse.git#fe76abaf8120d4a03f0dfa25c2ae9090f9a90c51",
-            "from": "git+https://github.com/Exabyte-io/esse.git#feat/SOF-6914-1",
-            "requires": {
-                "@babel/cli": "7.16.0",
-                "@babel/core": "7.16.0",
-                "@babel/eslint-parser": "7.16.3",
-                "@babel/preset-env": "7.16.4",
-                "@babel/register": "7.16.0",
-                "ajv": "^4.1.7",
-                "file": "^0.2.2",
-                "js-yaml": "^4.1.0",
-                "json-schema-deref-sync": "0.14.0",
-                "lodash": "4.17.21"
-            },
-            "dependencies": {
-                "@babel/register": {
-                    "version": "7.16.0",
-                    "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.16.0.tgz",
-                    "integrity": "sha512-lzl4yfs0zVXnooeLE0AAfYaT7F3SPA8yB2Bj4W1BiZwLbMS3MZH35ZvCWSRHvneUugwuM+Wsnrj7h0F7UmU3NQ==",
-                    "requires": {
-                        "clone-deep": "^4.0.1",
-                        "find-cache-dir": "^2.0.0",
-                        "make-dir": "^2.1.0",
-                        "pirates": "^4.0.0",
-                        "source-map-support": "^0.5.16"
-                    }
-                }
-            }
-        },
         "@humanwhocodes/config-array": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -1527,6 +1497,38 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
             "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+        },
+        "@mat3ra/esse": {
+            "version": "2024.1.18-0",
+            "resolved": "https://registry.npmjs.org/@mat3ra/esse/-/esse-2024.1.18-0.tgz",
+            "integrity": "sha512-GqdKXYJS0M5FxmGeo8H1QT7o80lULGvLPm0kmHaw5Q3NWFcb8ZWLAfSuy2T0tIJt6KtwlWKns9axkH2SaNmQ6Q==",
+            "requires": {
+                "@babel/cli": "7.16.0",
+                "@babel/core": "7.16.0",
+                "@babel/eslint-parser": "7.16.3",
+                "@babel/preset-env": "7.16.4",
+                "@babel/register": "7.16.0",
+                "ajv": "^4.1.7",
+                "file": "^0.2.2",
+                "js-yaml": "^4.1.0",
+                "json-schema-deref-sync": "0.14.0",
+                "json-schema-merge-allof": "^0.8.1",
+                "lodash": "4.17.21"
+            },
+            "dependencies": {
+                "@babel/register": {
+                    "version": "7.16.0",
+                    "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.16.0.tgz",
+                    "integrity": "sha512-lzl4yfs0zVXnooeLE0AAfYaT7F3SPA8yB2Bj4W1BiZwLbMS3MZH35ZvCWSRHvneUugwuM+Wsnrj7h0F7UmU3NQ==",
+                    "requires": {
+                        "clone-deep": "^4.0.1",
+                        "find-cache-dir": "^2.0.0",
+                        "make-dir": "^2.1.0",
+                        "pirates": "^4.0.0",
+                        "source-map-support": "^0.5.16"
+                    }
+                }
+            }
         },
         "@nicolo-ribaudo/chokidar-2": {
             "version": "2.1.8-no-fsevents.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,8 +1351,8 @@
             "dev": true
         },
         "@exabyte-io/esse.js": {
-            "version": "git+https://github.com/Exabyte-io/esse.git#96594df5dce47230b311c2a8b978c55c607090b9",
-            "from": "git+https://github.com/Exabyte-io/esse.git#96594df5dce47230b311c2a8b978c55c607090b9",
+            "version": "git+https://github.com/Exabyte-io/esse.git#dbba65549bf04b73c1d33f766d0c221fc563ba78",
+            "from": "git+https://github.com/Exabyte-io/esse.git#dbba65549bf04b73c1d33f766d0c221fc563ba78",
             "requires": {
                 "@babel/cli": "7.16.0",
                 "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,8 +1351,8 @@
             "dev": true
         },
         "@exabyte-io/esse.js": {
-            "version": "git+https://github.com/Exabyte-io/esse.git#75b21174c88528ff3b13b237d361863399be0331",
-            "from": "git+https://github.com/Exabyte-io/esse.git#75b21174c88528ff3b13b237d361863399be0331",
+            "version": "git+https://github.com/Exabyte-io/esse.git#4ee6d472c0c2a9fb0631e1574f7255cff778658d",
+            "from": "git+https://github.com/Exabyte-io/esse.git#4ee6d472c0c2a9fb0631e1574f7255cff778658d",
             "requires": {
                 "@babel/cli": "7.16.0",
                 "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,8 +1351,8 @@
             "dev": true
         },
         "@exabyte-io/esse.js": {
-            "version": "git+https://github.com/Exabyte-io/esse.git#60c8bee00c46b4f9e400f3461e0144049dedf7fb",
-            "from": "git+https://github.com/Exabyte-io/esse.git#60c8bee00c46b4f9e400f3461e0144049dedf7fb",
+            "version": "git+https://github.com/Exabyte-io/esse.git#fe76abaf8120d4a03f0dfa25c2ae9090f9a90c51",
+            "from": "git+https://github.com/Exabyte-io/esse.git#feat/SOF-6914-1",
             "requires": {
                 "@babel/cli": "7.16.0",
                 "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,8 +1351,8 @@
             "dev": true
         },
         "@exabyte-io/esse.js": {
-            "version": "git+https://github.com/Exabyte-io/esse.git#0cf877d5b577bd7325490efee718c373692710d6",
-            "from": "git+https://github.com/Exabyte-io/esse.git#0cf877d5b577bd7325490efee718c373692710d6",
+            "version": "git+https://github.com/Exabyte-io/esse.git#60c8bee00c46b4f9e400f3461e0144049dedf7fb",
+            "from": "git+https://github.com/Exabyte-io/esse.git#60c8bee00c46b4f9e400f3461e0144049dedf7fb",
             "requires": {
                 "@babel/cli": "7.16.0",
                 "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,8 +1351,8 @@
             "dev": true
         },
         "@exabyte-io/esse.js": {
-            "version": "git+https://github.com/Exabyte-io/esse.git#8b60a19ef713f95fafa56faa45abb6d7ce89a109",
-            "from": "git+https://github.com/Exabyte-io/esse.git#8b60a19ef713f95fafa56faa45abb6d7ce89a109",
+            "version": "git+https://github.com/Exabyte-io/esse.git#0cf877d5b577bd7325490efee718c373692710d6",
+            "from": "git+https://github.com/Exabyte-io/esse.git#0cf877d5b577bd7325490efee718c373692710d6",
             "requires": {
                 "@babel/cli": "7.16.0",
                 "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,9 +1574,8 @@
             "dev": true
         },
         "@exabyte-io/esse.js": {
-            "version": "2023.9.29-0",
-            "resolved": "https://registry.npmjs.org/@exabyte-io/esse.js/-/esse.js-2023.9.29-0.tgz",
-            "integrity": "sha512-KNitdwZkbIOY2HR8Hh6jU3NT8xiYuL7YPcOVdstkWX0x1+P8mOjs8lpwAmJePuPZVsUeYhlUi2wVADt8dnlCRQ==",
+            "version": "git+https://github.com/Exabyte-io/esse.git#977e66222141581f92190b05f1c19366ec3bc7d9",
+            "from": "git+https://github.com/Exabyte-io/esse.git#977e66222141581f92190b05f1c19366ec3bc7d9",
             "requires": {
                 "@babel/cli": "7.16.0",
                 "@babel/core": "7.16.0",
@@ -5508,7 +5507,7 @@
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "requires": {
                 "wrappy": "1"
             }
@@ -5590,12 +5589,12 @@
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
         },
         "path-key": {
             "version": "3.1.1",
@@ -6084,7 +6083,7 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         },
         "source-map-support": {
             "version": "0.5.21",
@@ -6158,7 +6157,7 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
         "string-argv": {
@@ -6345,7 +6344,7 @@
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -6686,7 +6685,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "write-file-atomic": {
             "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,8 +1351,8 @@
             "dev": true
         },
         "@exabyte-io/esse.js": {
-            "version": "git+https://github.com/Exabyte-io/esse.git#dbba65549bf04b73c1d33f766d0c221fc563ba78",
-            "from": "git+https://github.com/Exabyte-io/esse.git#dbba65549bf04b73c1d33f766d0c221fc563ba78",
+            "version": "git+https://github.com/Exabyte-io/esse.git#8b60a19ef713f95fafa56faa45abb6d7ce89a109",
+            "from": "git+https://github.com/Exabyte-io/esse.git#8b60a19ef713f95fafa56faa45abb6d7ce89a109",
             "requires": {
                 "@babel/cli": "7.16.0",
                 "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#ba911ea6baab8b7ccb95d0fc079c36e9294b672d",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#82183ba9e3b2e17e62fa2201d58b729fbfc94a34",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#dbba65549bf04b73c1d33f766d0c221fc563ba78",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#8b60a19ef713f95fafa56faa45abb6d7ce89a109",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#96594df5dce47230b311c2a8b978c55c607090b9",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#dbba65549bf04b73c1d33f766d0c221fc563ba78",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#75b21174c88528ff3b13b237d361863399be0331",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#4ee6d472c0c2a9fb0631e1574f7255cff778658d",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#82183ba9e3b2e17e62fa2201d58b729fbfc94a34",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#977e66222141581f92190b05f1c19366ec3bc7d9",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#feat/SOF-6914-1",
+        "@mat3ra/esse": "^2024.1.18-0",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#0cf877d5b577bd7325490efee718c373692710d6",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#60c8bee00c46b4f9e400f3461e0144049dedf7fb",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "2023.8.31-0",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#ba911ea6baab8b7ccb95d0fc079c36e9294b672d",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#8b60a19ef713f95fafa56faa45abb6d7ce89a109",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#0cf877d5b577bd7325490efee718c373692710d6",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "^7.16.0",
         "@babel/runtime-corejs3": "7.16.8",
-        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#60c8bee00c46b4f9e400f3461e0144049dedf7fb",
+        "@exabyte-io/esse.js": "git+https://github.com/Exabyte-io/esse#feat/SOF-6914-1",
         "@types/chai": "^4.3.5",
         "@types/crypto-js": "^4.1.1",
         "@types/js-yaml": "^4.0.5",

--- a/src/JSONSchemasInterface.ts
+++ b/src/JSONSchemasInterface.ts
@@ -1,8 +1,4 @@
-import baseSchema, {
-    JSONSchema,
-    JSONSchemaDefinition,
-    JSONSchemaType,
-} from "@exabyte-io/esse.js/schema";
+import baseSchema, { JSONSchema, JSONSchemaDefinition, JSONSchemaType } from "@mat3ra/esse/schema";
 import Ajv, { Options } from "ajv";
 import deref from "json-schema-deref-sync";
 import mergeAllOf from "json-schema-merge-allof";

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,5 +1,5 @@
 declare module "json-schema-deref-sync" {
-    import { JSONSchema, JSONSchemaDefinition } from "@exabyte-io/esse.js/schema";
+    import { JSONSchema, JSONSchemaDefinition } from "@mat3ra/esse/schema";
 
     function deref(globalSchema: JSONSchema): JSONSchema;
     function deref(globalSchema: JSONSchemaDefinition): JSONSchemaDefinition;
@@ -32,7 +32,7 @@ declare module "json-schema-merge-allof" {
  * This types are originally from "@types/json-schema" npm package.
  * The one difference compared to the original implementation is schemaId property to JSONSchema interface
  */
-declare module "@exabyte-io/esse.js/schema" {
+declare module "@mat3ra/esse/schema" {
     export {
         JSONSchema6 as JSONSchema,
         JSONSchema6Definition as JSONSchemaDefinition,
@@ -40,7 +40,7 @@ declare module "@exabyte-io/esse.js/schema" {
     } from "json-schema";
 }
 
-declare module "@exabyte-io/esse.js/lib/js/esse/schemaUtils" {
+declare module "@mat3ra/esse/lib/js/esse/schemaUtils" {
     // TODO: add TS to esse.js
 
     export function mapObjectDeep(object: object, mapValue: () => unknown): object;

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -1,4 +1,4 @@
-import { JSONSchema } from "@exabyte-io/esse.js/schema";
+import { JSONSchema } from "@mat3ra/esse/schema";
 import { JSONSchema7Definition } from "json-schema";
 import forEach from "lodash/forEach";
 import hasProperty from "lodash/has";
@@ -6,7 +6,7 @@ import isEmpty from "lodash/isEmpty";
 
 import { JSONSchemasInterface } from "../JSONSchemasInterface";
 
-export * from "@exabyte-io/esse.js/lib/js/esse/schemaUtils";
+export * from "@mat3ra/esse/lib/js/esse/schemaUtils";
 
 export const schemas: { [key: string]: string } = {};
 


### PR DESCRIPTION
This PR only carries the schema changes from esse through to the web-app by updating code.js dependency on esse.